### PR TITLE
퀴즈셋팅페이지 문제 및 시간 제한 설정 기능 추가

### DIFF
--- a/components/quiz/QuizSetting.tsx
+++ b/components/quiz/QuizSetting.tsx
@@ -6,16 +6,16 @@ import { useRouter } from 'next/navigation';
 import QuizTypeSelect from './QuizTypeSelect';
 
 export default function QuizSetting() {
-  const [questionNum, setQuestionNum] = useState(10);
+  const [questionNum, setQuestionNum] = useState(5);
   const [timerDuration, setTimerDuration] = useState(10);
   const [quizType, setQuizType] = useState('프론트엔드');
   const router = useRouter();
 
   const handleIncrease = (name: string) => {
     if (name === 'questionNum') {
-      setQuestionNum((prev) => prev + 5);
+      setQuestionNum((prev) => Math.min(prev + 5, 50));
     } else if (name === 'timerDuration') {
-      setTimerDuration((prev) => prev + 5);
+      setTimerDuration((prev) => Math.min(prev + 5, 100));
     }
   };
 


### PR DESCRIPTION
# 📢 Summary
퀴즈셋팅페이지 문제 및 시간 제한 설정 기능 추가
</br>

# 📑 Describe your changes
- 퀴즈 유저 셋팅 페이지 문제 및 시간 제한 min,max 설정
- Math.max 사용하여 최소 문제 및 시간 설정(5문제 / 5초)
- Math.min 사용하여 최대 문제 및 시간 설정(50문제 / 100초)
</br>

# ✏ Issue number and link
- #11 
  </br>

# 📋 Checklist
- [ ] check
      </br>

# 📝 Additional Notes

- </br>

# 🚦 Deployment Impact

-
